### PR TITLE
Handle scale edge cases in TermBuilder.tf and TermBuilder.tx

### DIFF
--- a/src/liesel_gam/term_builder.py
+++ b/src/liesel_gam/term_builder.py
@@ -2921,10 +2921,15 @@ class TermBuilder:
         coef_name = self.names.beta(fname)
 
         if common_scale is not None and not isinstance(common_scale, float):
-            common_scale = self.init_scale(common_scale, fname)
-            _biject_and_replace_star_gibbs_with(
-                common_scale, self._get_inference(scales_inference)
-            )
+            if isinstance(common_scale, VarIGPrior):
+                common_scale = self.init_scale(common_scale, fname)
+                _biject_and_replace_star_gibbs_with(
+                    common_scale,
+                    self._get_inference(scales_inference),
+                    override_none_inference=True,
+                )
+            else:
+                common_scale = self.init_scale(common_scale, fname)
         elif common_scale is not None:
             common_scale = self.init_scale(common_scale, fname)
 
@@ -3356,10 +3361,15 @@ class TermBuilder:
         fname = term_name
 
         if common_scale is not None and not isinstance(common_scale, float):
-            common_scale = self.init_scale(common_scale, fname)
-            _biject_and_replace_star_gibbs_with(
-                common_scale, self._get_inference(scales_inference)
-            )
+            if isinstance(common_scale, VarIGPrior):
+                common_scale = self.init_scale(common_scale, fname)
+                _biject_and_replace_star_gibbs_with(
+                    common_scale,
+                    self._get_inference(scales_inference),
+                    override_none_inference=True,
+                )
+            else:
+                common_scale = self.init_scale(common_scale, fname)
         elif common_scale is not None:
             common_scale = self.init_scale(common_scale, fname)
 
@@ -3436,7 +3446,9 @@ def _find_parameter(var: lsl.Var) -> lsl.Var:
 
 
 def _biject_and_replace_star_gibbs_with(
-    var: lsl.Var, inference: InferenceTypes | None
+    var: lsl.Var,
+    inference: InferenceTypes | None,
+    override_none_inference: bool = False,
 ) -> lsl.Var:
     """
     If var is a ScaleIG, it is the square root of a variance
@@ -3445,20 +3457,24 @@ def _biject_and_replace_star_gibbs_with(
     space bijector and sets the inference to the 'inference' supplied to the function.
     """
     param = _find_parameter(var)
-    if param.inference is not None:
-        if isinstance(param.inference, gs.MCMCSpec):
-            try:
-                is_star_gibbs = param.inference.kernel.__name__ == "StarVarianceGibbs"  # type: ignore
-                if not is_star_gibbs:
-                    return var
-            except AttributeError:
-                # in this case, we assume that the inference has been set intentionally
-                # so we don't change anything
+
+    if param.inference is None and not override_none_inference:
+        return var
+
+    if isinstance(param.inference, gs.MCMCSpec):
+        try:
+            is_star_gibbs = param.inference.kernel.__name__ == "StarVarianceGibbs"  # type: ignore
+            if not is_star_gibbs:
                 return var
-        else:
+        except AttributeError:
             # in this case, we assume that the inference has been set intentionally
             # so we don't change anything
             return var
+    elif param.inference is not None:
+        # in this case, we assume that the inference has been set intentionally
+        # so we don't change anything
+        return var
+
     if param.name:
         trafo_name = "ln(" + param.name + ")"
     else:
@@ -3466,6 +3482,7 @@ def _biject_and_replace_star_gibbs_with(
     transformed = param.transform(
         bijector=tfb.Exp(), inference=inference, name=trafo_name
     )
+    transformed.update()
     if trafo_name is None:
         transformed.name = ""
     return var

--- a/tests/test_term_builder.py
+++ b/tests/test_term_builder.py
@@ -749,6 +749,16 @@ class TestTPTerm:
             if i > 0:
                 assert ta.scales[i] is ta.scales[i - 1]
 
+        scale_inference = gs.MCMCSpec(gs.HMCKernel)
+        ta = tb.tf(psy, psx, common_scale=scale_wb(inference=scale_inference))
+        assert ta.terms_by_order[2][0].basis.value.shape == (49, 9 * 9)
+        for i in range(len(ta.scales)):
+            assert ta.scales[i].value_node[0].strong
+            assert ta.scales[i].inference is None
+            assert ta.scales[i].value_node[0].inference is scale_inference
+            if i > 0:
+                assert ta.scales[i] is ta.scales[i - 1]
+
     def test_intentional_inference(self, columb):
         tb = gb.TermBuilder.from_df(columb)
         psy = tb.ps("y", k=10)

--- a/tests/test_term_builder.py
+++ b/tests/test_term_builder.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import tensorflow_probability.substrates.jax.bijectors as tfb
+import tensorflow_probability.substrates.jax.distributions as tfd
 from liesel.contrib import splines as spl
 from ryp import r, to_py
 
@@ -17,6 +18,41 @@ import liesel_gam.term_builder as gb
 from liesel_gam.term_builder import _find_parameter, _format_name, _has_star_gibbs
 
 from .make_df import make_test_df
+
+
+def scale_wb(
+    value: float = 0.5,
+    scale: float = 0.5,
+    bijector: tfb.Bijector = tfb.Exp(),
+    name: str = "{x}",
+    inference: gs.MCMCSpec | None = None,
+):
+    prior = lsl.Dist(
+        tfd.Weibull,
+        concentration=jnp.asarray(0.5),
+        scale=jnp.asarray(scale),
+    )
+    scale_var = lsl.Var.new_param(jnp.asarray(value), prior, name=name)
+    return scale_var.biject(bijector, inference=inference)
+
+
+def scale_ig(
+    value: float = 0.5,
+    concentration: float = 1.0,
+    scale: float = 0.005,
+    bijector: tfb.Bijector = tfb.Exp(),
+    name: str = "{x}",
+    inference: gs.MCMCSpec | None = None,
+):
+    prior = lsl.Dist(
+        tfd.InverseGamma,
+        concentration=jnp.asarray(concentration),
+        scale=jnp.asarray(scale),
+    )
+    variance_var = lsl.Var.new_param(jnp.asarray(value), prior, name="{x}^2")
+    variance_var.biject(bijector, inference=inference)
+    scale_var = lsl.Var.new_calc(jnp.sqrt, variance_var, name=name)
+    return scale_var
 
 
 @pytest.fixture(scope="module")
@@ -691,6 +727,7 @@ class TestTPTerm:
         psy = tb.ps("y", k=10)
         psx = tb.ps("x", k=10)
         ta = tb.tx(psy, psx, common_scale=gam.VarIGPrior(1.0, 0.005))
+
         assert ta.basis.value.shape == (49, 9 * 9)
         for i in range(len(ta.scales)):
             assert ta.scales[i].value_node[0].value_node[0].inference is not None
@@ -760,6 +797,65 @@ class TestTPTerm:
         ps = tb.ps("x", k=10)
         ta = tb.tx(mrf, ps)
         assert ta.basis.value.shape == (49, 9 * 48)
+
+    @pytest.mark.parametrize("method", ("tx", "tf"))
+    def test_wb_scale(self, columb, method):
+        tb = gb.TermBuilder.from_df(columb)
+        sy_inference = gs.MCMCSpec(gs.HMCKernel)
+        psy = tb.ps("y", k=10, scale=scale_wb(inference=sy_inference))
+        psx = tb.ps("x", k=10, scale=scale_wb())
+
+        getattr(tb, method)(psy, psx)
+
+        assert not jnp.isnan(psy.scale.value_node[0].log_prob)
+        assert not jnp.isnan(psx.scale.value_node[0].log_prob)
+
+        assert psy.scale.value_node[0].strong
+        assert psx.scale.value_node[0].strong
+
+        assert psy.scale.value_node[0].inference is sy_inference
+        assert psx.scale.value_node[0].inference is None
+
+    @pytest.mark.parametrize("method", ("tx", "tf"))
+    def test_ig_scale(self, columb, method):
+        tb = gb.TermBuilder.from_df(columb)
+        sy_inference = gs.MCMCSpec(gs.HMCKernel)
+        psy = tb.ps("y", k=10, scale=scale_ig(inference=sy_inference))
+        psx = tb.ps("x", k=10, scale=scale_ig())
+
+        getattr(tb, method)(psy, psx)
+
+        yvar = psy.scale.value_node[0]
+        xvar = psx.scale.value_node[0]
+
+        assert not jnp.isnan(yvar.value_node[0].log_prob)
+        assert not jnp.isnan(xvar.value_node[0].log_prob)
+
+        assert yvar.value_node[0].strong
+        assert xvar.value_node[0].strong
+
+        assert yvar.value_node[0].inference is sy_inference
+        assert xvar.value_node[0].inference is None
+
+    @pytest.mark.parametrize("method", ("tx", "tf"))
+    def test_ig_scale_gibbs(self, columb, method):
+        tb = gb.TermBuilder.from_df(columb)
+        psy = tb.ps("y", k=10)
+        psx = tb.ps("x", k=10)
+
+        getattr(tb, method)(psy, psx)
+
+        yvar = psy.scale.value_node[0]
+        xvar = psx.scale.value_node[0]
+
+        assert not jnp.isnan(yvar.value_node[0].log_prob)
+        assert not jnp.isnan(xvar.value_node[0].log_prob)
+
+        assert yvar.value_node[0].strong
+        assert xvar.value_node[0].strong
+
+        assert yvar.value_node[0].inference.kernel is gs.HMCKernel
+        assert xvar.value_node[0].inference.kernel is gs.HMCKernel
 
 
 class TestHasStarGibbs:


### PR DESCRIPTION
When a scale with `.inference = None` is passed, it is now left unchanged by `TermBuilder.tx` and `TermBuilder.tf`. Previously, an exponential bijector was applied automatically, and the scale was equipped with the default scale inference specification automatically. Now, this happens only for 

- a) `common_scale`s specified as `gam.VarIGPrior` (because users would reasonably expect automatic inference specification when using `gam.VarIGPrior`) 
- b) scales from the marginal terms that have Gibbs kernels set up (because Gibbs kernels become invalid in anisotropic tensor products)