### PR TITLE
Ensure unique basis node names for subterms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ requires-python = ">=3.13,<3.14"
 dependencies = [
     "formulaic>=1.2.1",
     "liesel>=0.4.2",
+    # arviz-plots currently imports matplotlib.style.core, which is not
+    # available in matplotlib 3.11.
+    "matplotlib<3.11",
     "smoothcon>=0.0.10",
     "plotnine>=0.14.5"
 ]

--- a/src/liesel_gam/term.py
+++ b/src/liesel_gam/term.py
@@ -2075,6 +2075,12 @@ class StrctTensorProdTerm(UserVar):
             term.name = names_prefix + f"{tx_name}({term.xnames})"
             term.coef.name = names_prefix + "$" + coef_name + r"_{" + term.name + r"}$"
             term.basis.name = names_prefix + basis_name + "(" + term.xnames + ")"
+            term.basis.value_node.name = (
+                names_prefix + basis_name + "(" + term.xnames + ")" + "_value_node"
+            )
+            term.basis.var_value_node.name = (
+                names_prefix + basis_name + "(" + term.xnames + ")" + "_var_value_node"
+            )
 
             interactions.append(term)
 

--- a/src/liesel_gam/term_builder.py
+++ b/src/liesel_gam/term_builder.py
@@ -3377,6 +3377,18 @@ class TermBuilder:
         )
         term.name = term_name
 
+        for subterms_order, subterms in term.terms_by_order.items():
+            if subterms_order == 1:
+                continue
+            for this_subterm in subterms:
+                this_subterm.basis.name = self.names.create(this_subterm.basis.name)
+                this_subterm.basis.value_node.name = self.names.create(
+                    this_subterm.basis.value_node.name
+                )
+                this_subterm.basis.var_value_node.name = self.names.create(
+                    this_subterm.basis.var_value_node.name
+                )
+
         first_order_bases = []
         for term_ in term.terms_by_order[1]:
             first_order_bases.append(term_.basis)

--- a/tests/test_term_builder.py
+++ b/tests/test_term_builder.py
@@ -3,19 +3,19 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
-import liesel_gam as gam
-import liesel_gam.term_builder as gb
+import liesel.goose as gs
+import liesel.model as lsl
 import numpy as np
 import pandas as pd
 import pytest
 import tensorflow_probability.substrates.jax.bijectors as tfb
 import tensorflow_probability.substrates.jax.distributions as tfd
-from liesel_gam.term_builder import _find_parameter, _format_name, _has_star_gibbs
+from liesel.contrib import splines as spl
 from ryp import r, to_py
 
-import liesel.goose as gs
-import liesel.model as lsl
-from liesel.contrib import splines as spl
+import liesel_gam as gam
+import liesel_gam.term_builder as gb
+from liesel_gam.term_builder import _find_parameter, _format_name, _has_star_gibbs
 
 from .make_df import make_test_df
 

--- a/tests/test_term_builder.py
+++ b/tests/test_term_builder.py
@@ -761,6 +761,40 @@ class TestTPTerm:
         ta = tb.tx(mrf, ps)
         assert ta.basis.value.shape == (49, 9 * 48)
 
+    @pytest.mark.parametrize("prefix", (False, True))
+    @pytest.mark.parametrize("method", ("tx", "tf"))
+    def test_basis_name_handling(self, columb, method, prefix):
+        tb = gb.TermBuilder.from_df(columb)
+        psx1 = tb.ps("x", k=10, prefix="l." if prefix else "")
+        psy1 = tb.ps("y", k=10, prefix="l." if prefix else "")
+        tx1 = getattr(tb, method)(psx1, psy1, prefix="l." if prefix else "")
+
+        psx2 = tb.ps("x", k=10, prefix="s." if prefix else "")
+        psy2 = tb.ps("y", k=10, prefix="s." if prefix else "")
+        tx2 = getattr(tb, method)(psx2, psy2, prefix="s." if prefix else "")
+
+        model = lsl.Model([tx1, tx2])
+        assert model is not None
+
+    @pytest.mark.parametrize("prefix", (False, True))
+    @pytest.mark.parametrize("method", ("tx", "tf"))
+    def test_basis_name_handling_two_termbuilders(self, columb, method, prefix):
+        tb1 = gb.TermBuilder.from_df(columb, prefix_names_by="l." if prefix else "")
+        psx1 = tb1.ps("x", k=10)
+        psy1 = tb1.ps("y", k=10)
+        tx1 = getattr(tb1, method)(psx1, psy1)
+
+        tb2 = gb.TermBuilder.from_df(columb, prefix_names_by="s." if prefix else "")
+        psx2 = tb2.ps("x", k=10)
+        psy2 = tb2.ps("y", k=10)
+        tx2 = getattr(tb2, method)(psx2, psy2)
+
+        if not prefix:
+            with pytest.raises(RuntimeError, match="Duplicate node names"):
+                lsl.Model([tx1, tx2])
+        else:
+            lsl.Model([tx1, tx2])
+
 
 class TestHasStarGibbs:
     def test_term(self, columb):

--- a/uv.lock
+++ b/uv.lock
@@ -996,6 +996,7 @@ source = { editable = "." }
 dependencies = [
     { name = "formulaic" },
     { name = "liesel" },
+    { name = "matplotlib" },
     { name = "plotnine" },
     { name = "smoothcon" },
 ]
@@ -1022,6 +1023,7 @@ dev = [
 requires-dist = [
     { name = "formulaic", specifier = ">=1.2.1" },
     { name = "liesel", specifier = ">=0.4.2" },
+    { name = "matplotlib", specifier = "<3.11" },
     { name = "plotnine", specifier = ">=0.14.5" },
     { name = "smoothcon", specifier = ">=0.0.10" },
 ]


### PR DESCRIPTION
This PR makes sure that multiple tensor products initialized via the same TermBuilder have unique basis node names, so there are no name clashes.

Previously problematic code that now works:

```python
tb = gb.TermBuilder.from_df(columb)

psx1 = tb.ps("x", k=10)
psy1 = tb.ps("y", k=10)
tx1 = tb.tf(psx1, psy1)

psx2 = tb.ps("x", k=10)
psy2 = tb.ps("y", k=10)
tx2 = tb.tf(psx2, psy2)

model = lsl.Model([tx1, tx2]) # raised error with name clash before this PR, now not anymore
```

Previously, the desired behavior could also be achieved, but required two termbuilders with at least one of them having a name prefix:

```python
tb = gb.TermBuilder.from_df(columb, prefix_names_by="l.")

psx1 = tb.ps("x", k=10)
psy1 = tb.ps("y", k=10)
tx1 = tb.tf(psx1, psy1)

tb = gb.TermBuilder.from_df(columb, prefix_names_by="s.")
psx2 = tb.ps("x", k=10)
psy2 = tb.ps("y", k=10)
tx2 = tb.tf(psx2, psy2)

model = lsl.Model([tx1, tx2]) # no error
```