### PR TITLE
Fix automatic naming with prefixes for multi-variable single-scale terms

### DIFF
--- a/src/liesel_gam/basis_builder.py
+++ b/src/liesel_gam/basis_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping, Sequence
 from math import ceil
-from typing import Any, Literal, get_args
+from typing import Any, Literal, cast, get_args
 
 import formulaic as fo
 import jax
@@ -254,6 +254,49 @@ class BasisBuilder:
             raise TypeError(f"Type {type(x)} not supported for 'x'.")
 
         return x_var, x_array
+
+    def _get_matrix(
+        self, *x: str | lsl.Var, cache: bool = False
+    ) -> lsl.Calc | lsl.TransientCalc:
+        """Get a calculation node that column-stacks named or supplied variables.
+
+        All inputs must be either names of numeric registry variables or named
+        ``lsl.Var`` objects. Registry-backed matrices are cached by the registry;
+        matrices from supplied variables are created directly.
+        """
+        all_str = all([isinstance(x_, str) for x_ in x])
+        all_var = all([isinstance(x_, lsl.Var) for x_ in x])
+
+        if all_str:
+            names = cast(tuple[str, ...], x)
+            calc: lsl.Calc | lsl.TransientCalc = self.registry.get_many_numeric_obs(
+                *names, cache=cache
+            )
+            return calc
+
+        if not all_var:
+            raise ValueError(
+                f"Must supply either only variables or only names, got {x}."
+            )
+
+        vars_ = cast(tuple[lsl.Var, ...], x)
+        xname = ",".join([v.name for v in vars_])
+        xname = self.names.create(f"[{xname}]")
+
+        if not cache:
+            calc = lsl.TransientCalc(
+                lambda *args: jnp.vstack(args).T,
+                *vars_,
+                _name=xname,
+            )
+        else:
+            calc = lsl.Calc(
+                lambda *args: jnp.vstack(args).T,
+                *vars_,
+                _name=xname,
+            )
+
+        return calc
 
     def ps(
         self,
@@ -924,8 +967,8 @@ class BasisBuilder:
 
         obs_vars = {}
         for xname in x:
-            xvar: lsl.Var | lsl.TransientCalc = self._get_var_and_value(xname)[0]
-            obs_vars[xvar.name] = xvar
+            obs_var = self._get_var_and_value(xname)[0]
+            obs_vars[obs_var.name] = obs_var
 
         obs_values = {k: np.asarray(v.value) for k, v in obs_vars.items()}
         obs_names = [v.name for v in obs_vars.values()]
@@ -942,13 +985,8 @@ class BasisBuilder:
         )
 
         xname = ",".join([v.name for v in obs_vars.values()])
-
         if len(obs_vars) > 1:
-            xvar = lsl.TransientCalc(  # for memory-efficiency
-                lambda *args: jnp.vstack(args).T,
-                *list(obs_vars.values()),
-                _name=self.names.create(xname),
-            )
+            xvar: lsl.Calc | lsl.TransientCalc | lsl.Var = self._get_matrix(*x)
         else:
             xvar = obs_vars[xname]
 

--- a/src/liesel_gam/registry.py
+++ b/src/liesel_gam/registry.py
@@ -66,6 +66,7 @@ class PandasRegistry:
         self.na_action = na_action
         self.data = self._validate_data(data)
         self._var_cache: dict[str, lsl.Var] = {}
+        self._matrix_cache: dict[str, lsl.Calc | lsl.TransientCalc] = {}
         self._derived_cache: dict[str, lsl.Var] = {}
         self.prefix = prefix_names_by
 
@@ -209,6 +210,45 @@ class PandasRegistry:
             self._var_cache[name] = var
 
         return var
+
+    def get_many_numeric_obs(
+        self, *names: str, cache: bool = False
+    ) -> lsl.Calc | lsl.TransientCalc:
+        """Get a calculation node that column-stacks several numeric variables.
+
+        Args:
+            *names: Names of numeric variables to retrieve from the registry.
+            cache: If ``True``, return a persistent ``Calc`` node. If ``False``,
+                return a memory-saving ``TransientCalc`` node.
+
+        Returns:
+            A calculation node with one column per requested variable.
+
+        Raises:
+            TypeError: If any requested variable is not numeric.
+            KeyError: If any requested variable is not present in the data.
+        """
+        name = ",".join([self.prefix + name_ for name_ in names])
+        if name in self._matrix_cache:
+            return self._matrix_cache[name]
+
+        vars_ = [self.get_numeric_obs(name_) for name_ in names]
+
+        if not cache:
+            calc: lsl.Calc | lsl.TransientCalc = lsl.TransientCalc(
+                lambda *args: jnp.vstack(args).T,
+                *vars_,
+                _name=name,
+            )
+        else:
+            calc = lsl.Calc(
+                lambda *args: jnp.vstack(args).T,
+                *vars_,
+                _name=name,
+            )
+
+        self._matrix_cache[name] = calc
+        return calc
 
     def _make_derived_var(
         self, base_var: lsl.Var, transform: Callable, var_name: str | None

--- a/tests/test_term_builder.py
+++ b/tests/test_term_builder.py
@@ -68,6 +68,37 @@ class TestTermBuilder:
         sx = tb.ps("x", k=10, prefix="test.")
         assert sx.name == "test.ps(x)"
 
+        registry = gb.PandasRegistry(columb, na_action="drop")
+        tb = gb.TermBuilder(registry)
+        sx = tb.kriging("x", "y", k=10, prefix="test.")
+        assert sx.name == "test.kriging(x,y)"
+
+        registry = gb.PandasRegistry(columb, na_action="drop")
+        tb = gb.TermBuilder(registry, prefix_names_by="test.")
+        sx1 = tb.kriging("x", "y", k=10)
+        assert sx1.name == "test.kriging(x,y)"
+
+        sx2 = tb.kriging("x", "y", k=10)
+        assert sx2.name == "test.kriging(x,y)1"
+
+        lsl.Model([sx1, sx2])
+
+    def test_supply_variables(self, columb) -> None:
+        registry = gb.PandasRegistry(columb, na_action="drop")
+
+        x = registry.get_numeric_obs("x")
+        y = registry.get_numeric_obs("y")
+        tb = gb.TermBuilder(registry, prefix_names_by="test.")
+
+        sx1 = tb.kriging(x, y, k=10)
+
+        assert sx1.name == "test.kriging(test.[x,y])"
+
+        sx2 = tb.kriging(x, y, k=10)
+        assert sx2.name == "test.kriging(test.[x,y]1)"
+
+        lsl.Model([sx1, sx2])
+
     def test_init_scale(self, columb) -> None:
         tb = gb.TermBuilder.from_df(columb, prefix_names_by="test.")
         sx = tb.ps("x", k=10, scale=lsl.Var(1.0))


### PR DESCRIPTION
Previous behavior:

When some conditions were fulfilled, the automatic naming added a prefix that did not need to be there and looked inconsistent. The conditions:

- Using a name prefix on a TermBuilder and a registry without name prefix.
- Using one of the terms that act like single smooths but allow multiple input variables with multiple inputs.

Example:

```python
registry = gb.PandasRegistry(columb, na_action="drop")
tb = gb.TermBuilder(registry, prefix_names_by="test.")
sx = tb.kriging("x", "y", k=10)
sx.name == "test.kriging(test.x,y)"
```

The  `"test.x"` name looks wrong. It was an issue of a hidden calculator variable that was created in the `BasisBuilder` instead of being created and cached in the registry.

Now, such operations use the registry for caching correctly:

```python
registry = gb.PandasRegistry(columb, na_action="drop")
tb = gb.TermBuilder(registry, prefix_names_by="test.")
sx = tb.kriging("x", "y", k=10)
sx.name == "test.kriging(x,y)"
```