### PR TITLE
Add include_intercept option to linear terms

### DIFF
--- a/src/liesel_gam/basis_builder.py
+++ b/src/liesel_gam/basis_builder.py
@@ -1454,7 +1454,9 @@ class BasisBuilder:
             fo.ModelSpec(formula, output="pandas")
             .get_model_matrix(self.data, context=context)
             .columns
-        )[1:]
+        )
+        if not include_intercept:
+            column_names = column_names[1:]
 
         required = sorted(str(var) for var in spec.required_variables)
         df_subset = self.data.loc[:, required]

--- a/src/liesel_gam/term_builder.py
+++ b/src/liesel_gam/term_builder.py
@@ -443,6 +443,7 @@ class TermBuilder:
         context: dict[str, Any] | None = None,
         prefix: str = "",
         name: str | None = None,
+        include_intercept: bool = False,
     ) -> LinTerm:
         """
         Linear term.
@@ -470,6 +471,8 @@ class TermBuilder:
         name
             Manually defined name of the term. If a prefix is specified, the prefix
             will be added to this name.
+        include_intercept
+            Whether to include an intercept column in the design matrix.
 
         See Also
         --------
@@ -551,8 +554,6 @@ class TermBuilder:
         .. _grammar: https://matthewwardrop.github.io/formulaic/latest/guides/grammar/
         """
 
-        include_intercept = False
-
         basis = self.bases.lin(
             formula,
             xname="",
@@ -589,6 +590,7 @@ class TermBuilder:
         factor_scale: bool = False,
         prefix: str = "",
         name: str | None = None,
+        include_intercept: bool = False,
     ) -> StrctLinTerm:
         """
         Linear term with an identity penalty matrix, leading to a ridge prior.
@@ -632,6 +634,8 @@ class TermBuilder:
         name
             Manually defined name of the term. If a prefix is specified, the prefix
             will be added to this name.
+        include_intercept
+            Whether to include an intercept column in the design matrix.
 
         See Also
         --------
@@ -687,8 +691,6 @@ class TermBuilder:
         .. _formulaic_categorical: https://matthew.wardrop.casa/formulaic/latest/guides/contrasts/#contrast-codings
         .. _grammar: https://matthewwardrop.github.io/formulaic/latest/guides/grammar/
         """
-        include_intercept = False
-
         basis = self.bases.lin(
             formula,
             xname="",

--- a/tests/test_term_builder.py
+++ b/tests/test_term_builder.py
@@ -187,6 +187,39 @@ class TestLinTerm:
         assert term.scale.value == pytest.approx(3.0)
         assert term.coef.dist_node["scale"].value == pytest.approx(3.0)
 
+    def test_lin_include_intercept(self, columb):
+        tb = gam.TermBuilder.from_df(columb)
+
+        term = tb.lin("x + y")
+        term_with_intercept = tb.lin("x + y", include_intercept=True)
+
+        basis = np.asarray(term.basis.value)
+        basis_with_intercept = np.asarray(term_with_intercept.basis.value)
+
+        assert basis_with_intercept.shape[-1] == basis.shape[-1] + 1
+        assert term_with_intercept.column_names == ["Intercept", "x", "y"]
+        assert np.any(np.all(np.isclose(basis_with_intercept, 1.0), axis=0))
+
+    def test_slin_include_intercept(self, columb):
+        tb = gam.TermBuilder.from_df(columb)
+
+        term = tb.slin("x + y")
+        term_with_intercept = tb.slin("x + y", include_intercept=True)
+
+        basis = np.asarray(term.basis.value)
+        basis_with_intercept = np.asarray(term_with_intercept.basis.value)
+
+        assert basis_with_intercept.shape[-1] == basis.shape[-1] + 1
+        assert term_with_intercept.column_names == ["Intercept", "x", "y"]
+        assert (
+            term_with_intercept.coef.value.shape[-1] == basis_with_intercept.shape[-1]
+        )
+        assert term_with_intercept.basis.penalty.value.shape == (
+            basis_with_intercept.shape[-1],
+            basis_with_intercept.shape[-1],
+        )
+        assert np.any(np.all(np.isclose(basis_with_intercept, 1.0), axis=0))
+
     def test_name(self, columb):
         tb = gam.TermBuilder.from_df(columb)
 


### PR DESCRIPTION
Expose an include_intercept boolean on TermBuilder.lin and TermBuilder.slin so callers can request an intercept column in the design matrix. BasisBuilder now respects this flag when computing column_names (only dropping the first column when include_intercept is False). Removed prior local overrides that forced include_intercept=False. Added tests to verify intercept column and shapes/penalties when include_intercept=True.