### PR TITLE
Additive predictor updates

### DIFF
--- a/src/liesel_gam/predictor.py
+++ b/src/liesel_gam/predictor.py
@@ -217,4 +217,12 @@ class AdditivePredictor(UserVar):
         return self.terms[name]
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self.name=}, {len(self.terms)} terms)"
+        if isinstance(self.intercept, lsl.Var):
+            intercept = repr(self.intercept.name)
+        else:
+            intercept = "False"
+
+        return (
+            f"{type(self).__name__}(name={self.name!r}, {len(self.terms)} terms, "
+            f"intercept={intercept})"
+        )

--- a/src/liesel_gam/predictor.py
+++ b/src/liesel_gam/predictor.py
@@ -22,8 +22,8 @@ class AdditivePredictor(UserVar):
 
     The untransformed additive sum is available as :attr:`linear_predictor`. The
     predictor's own value is the result of applying ``inv_link`` to this linear
-    predictor. The linear predictor is a calculation node, not a term, and is not
-    included in :attr:`terms`.
+    predictor. The linear predictor is a variable, not a term, and is not included in
+    :attr:`terms`.
 
     Parameters
     ----------
@@ -42,9 +42,9 @@ class AdditivePredictor(UserVar):
         If this name contains the placeholder ``{subscript}``, it will be filled with
         the predictor name to create a unique intercept name for this predictor.
     linear_predictor_name
-        Name of the linear predictor calculation node. If this name contains the
-        placeholder ``{subscript}``, it will be filled with the predictor name to
-        create a unique linear predictor name for this predictor.
+        Name of the linear predictor variable. If this name contains the placeholder
+        ``{subscript}``, it will be filled with the predictor name to create a unique
+        linear predictor name for this predictor.
 
     Examples
     --------
@@ -158,10 +158,9 @@ class AdditivePredictor(UserVar):
         else:
             intercept_ = 0.0
 
-        self._linear_predictor = lsl.Calc(
-            _sum,
-            intercept=intercept_,
-            _name=linear_predictor_name.format(subscript="_{" + name_cleaned + "}"),
+        self._linear_predictor = lsl.Var(
+            lsl.Calc(_sum, intercept=intercept_),
+            name=linear_predictor_name.format(subscript="_{" + name_cleaned + "}"),
         )
 
         super().__init__(lsl.Calc(inv_link, self._linear_predictor), name=name)
@@ -170,18 +169,18 @@ class AdditivePredictor(UserVar):
         """Dictionary of terms in this predictor."""
 
     @property
-    def linear_predictor(self) -> lsl.Calc:
+    def linear_predictor(self) -> lsl.Var:
         """Untransformed additive predictor on the link scale."""
         return self._linear_predictor
 
     @property
     def intercept(self) -> lsl.Var | lsl.Node:
         """This term's intercept."""
-        return self.linear_predictor["intercept"]
+        return self.linear_predictor.value_node["intercept"]
 
     @intercept.setter
     def intercept(self, value: lsl.Var | lsl.Node):
-        self.linear_predictor["intercept"] = value
+        self.linear_predictor.value_node["intercept"] = value
 
     def update(self) -> Self:
         self.linear_predictor.update()
@@ -214,7 +213,7 @@ class AdditivePredictor(UserVar):
         if term.name in self.terms:
             raise RuntimeError(f"{self} already contains a term of name {term.name}.")
 
-        self.linear_predictor.add_inputs(term)
+        self.linear_predictor.value_node.add_inputs(term)
         self.terms[term.name] = term
         self.update()
 

--- a/src/liesel_gam/predictor.py
+++ b/src/liesel_gam/predictor.py
@@ -20,14 +20,19 @@ class AdditivePredictor(UserVar):
     This is a special variable that allows you to add other Liesel varibales using the
     ``+=`` syntax (see examples).
 
+    The untransformed additive sum is available as :attr:`linear_predictor`. The
+    predictor's own value is the result of applying ``inv_link`` to this linear
+    predictor. The linear predictor is a calculation node, not a term, and is not
+    included in :attr:`terms`.
+
     Parameters
     ----------
     name
         Name of the predictor variable.
     inv_link
         Inverse link function. If supplied, variables are added on the *link* level,
-        and the predictor variable's value will be ``inv_link(sum(*inputs))``, where
-        ``*inputs`` refers to the additive terms in this predictor.
+        and the predictor variable's value will be the inverse link function applied
+        to :attr:`linear_predictor`.
     intercept
         Whether this predictor should be initialized with an intercept. You can supply
         booleans, or a :class:`liesel.model.Var`. In the latter case, this var is
@@ -36,6 +41,10 @@ class AdditivePredictor(UserVar):
         Name of the automatically created intercept variable (if ``intercept=True``).
         If this name contains the placeholder ``{subscript}``, it will be filled with
         the predictor name to create a unique intercept name for this predictor.
+    linear_predictor_name
+        Name of the linear predictor calculation node. If this name contains the
+        placeholder ``{subscript}``, it will be filled with the predictor name to
+        create a unique linear predictor name for this predictor.
 
     Examples
     --------
@@ -84,6 +93,8 @@ class AdditivePredictor(UserVar):
     {'s(x)': Var(name="s(x)")}
     >>> scale.intercept
     Var(name="$\\beta_{0,scale}$")
+    >>> scale.linear_predictor.value
+    Array(1., dtype=float32, weak_type=True)
     >>> scale.value
     Array(2.7182817, dtype=float32, weak_type=True)
 
@@ -123,6 +134,7 @@ class AdditivePredictor(UserVar):
         inv_link: Callable[[Array], Array] | None = None,
         intercept: bool | lsl.Var = True,
         intercept_name: str = "$\\beta{subscript}$",
+        linear_predictor_name: str = "$\\eta{subscript}$",
     ) -> None:
         if inv_link is None:
 
@@ -131,11 +143,10 @@ class AdditivePredictor(UserVar):
 
         def _sum(*args, intercept, **kwargs):
             # the + 0. implicitly ensures correct dtype also for empty predictors
-            return inv_link(sum(args) + sum(kwargs.values()) + 0.0 + intercept)
+            return sum(args) + sum(kwargs.values()) + 0.0 + intercept
 
+        name_cleaned = name.replace("$", "")
         if intercept and not isinstance(intercept, lsl.Var):
-            name_cleaned = name.replace("$", "")
-
             intercept_: lsl.Var | float = lsl.Var.new_param(
                 name=intercept_name.format(subscript="_{0," + name_cleaned + "}"),
                 value=0.0,
@@ -147,21 +158,33 @@ class AdditivePredictor(UserVar):
         else:
             intercept_ = 0.0
 
-        super().__init__(lsl.Calc(_sum, intercept=intercept_), name=name)
+        self._linear_predictor = lsl.Calc(
+            _sum,
+            intercept=intercept_,
+            _name=linear_predictor_name.format(subscript="_{" + name_cleaned + "}"),
+        )
+
+        super().__init__(lsl.Calc(inv_link, self._linear_predictor), name=name)
         self.update()
         self.terms: dict[str, term_types] = {}
         """Dictionary of terms in this predictor."""
 
     @property
+    def linear_predictor(self) -> lsl.Calc:
+        """Untransformed additive predictor on the link scale."""
+        return self._linear_predictor
+
+    @property
     def intercept(self) -> lsl.Var | lsl.Node:
         """This term's intercept."""
-        return self.value_node["intercept"]
+        return self.linear_predictor["intercept"]
 
     @intercept.setter
     def intercept(self, value: lsl.Var | lsl.Node):
-        self.value_node["intercept"] = value
+        self.linear_predictor["intercept"] = value
 
     def update(self) -> Self:
+        self.linear_predictor.update()
         return cast(Self, super().update())
 
     def __iadd__(self, other: term_types | Sequence[term_types]) -> Self:
@@ -191,7 +214,7 @@ class AdditivePredictor(UserVar):
         if term.name in self.terms:
             raise RuntimeError(f"{self} already contains a term of name {term.name}.")
 
-        self.value_node.add_inputs(term)
+        self.linear_predictor.add_inputs(term)
         self.terms[term.name] = term
         self.update()
 

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -77,3 +77,35 @@ class TestPredictor:
 
         pred = gam.AdditivePredictor("loc", intercept=False)
         assert isinstance(pred.intercept, lsl.Value)
+
+    def test_repr_default_intercept(self) -> None:
+        pred = gam.AdditivePredictor("loc")
+        assert (
+            repr(pred)
+            == "AdditivePredictor(name='loc', 0 terms, "
+            "intercept='$\\\\beta_{0,loc}$')"
+        )
+
+    def test_repr_custom_intercept(self) -> None:
+        intercept = lsl.Var.new_param(
+            value=1.0,
+            distribution=None,
+            name="b0",
+        )
+        pred = gam.AdditivePredictor("loc", intercept=intercept)
+        assert repr(pred) == "AdditivePredictor(name='loc', 0 terms, intercept='b0')"
+
+    def test_repr_disabled_intercept(self) -> None:
+        pred = gam.AdditivePredictor("loc", intercept=False)
+        assert repr(pred) == "AdditivePredictor(name='loc', 0 terms, intercept=False)"
+
+    def test_repr_term_count_excludes_intercept(self) -> None:
+        pred = gam.AdditivePredictor("loc")
+        pred += term1, term2
+
+        assert len(pred.terms) == 2
+        assert (
+            repr(pred)
+            == "AdditivePredictor(name='loc', 2 terms, "
+            "intercept='$\\\\beta_{0,loc}$')"
+        )

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -117,13 +117,15 @@ class TestPredictor:
 
         assert pred.linear_predictor.name == "eta_custom_{loc}"
 
-    def test_linear_predictor_is_model_node_not_var(self) -> None:
+    def test_linear_predictor_is_model_var(self) -> None:
         pred = gam.AdditivePredictor("loc")
         model = lsl.Model([pred])
 
-        assert pred.linear_predictor.name in model.nodes
-        assert pred.linear_predictor.name not in model.vars
+        assert pred.linear_predictor.value_node.name in model.nodes
+        assert pred.linear_predictor.var_value_node.name in model.nodes
+        assert pred.linear_predictor.name in model.vars
         assert pred.name in model.vars
+        assert pred.linear_predictor.weak
 
     def test_access_term(self) -> None:
         pred = gam.AdditivePredictor("loc")

--- a/tests/test_predictor.py
+++ b/tests/test_predictor.py
@@ -62,7 +62,68 @@ class TestPredictor:
     def test_inv_link(self) -> None:
         pred = gam.AdditivePredictor("loc", inv_link=jnp.exp)
         pred += term1
+        assert jnp.allclose(pred.linear_predictor.value, 1.0)
         assert jnp.allclose(pred.value, jnp.exp(1.0))
+
+    def test_linear_predictor_without_link(self) -> None:
+        pred = gam.AdditivePredictor("loc")
+        pred += term1
+
+        assert jnp.allclose(pred.linear_predictor.value, 1.0)
+        assert jnp.allclose(pred.value, pred.linear_predictor.value)
+
+    def test_linear_predictor_reflects_intercept_updates(self) -> None:
+        pred = gam.AdditivePredictor("scale", inv_link=jnp.exp)
+        pred += lsl.Var.new_value(1.0, name="s(x)")
+        intercept = pred.intercept
+        assert isinstance(intercept, lsl.Var)
+        intercept.value = 2.0
+        pred.update()
+
+        assert jnp.allclose(pred.linear_predictor.value, 3.0)
+        assert jnp.allclose(pred.value, jnp.exp(3.0))
+
+    def test_update_refreshes_linear_and_transformed_predictors(self) -> None:
+        term = lsl.Var.new_value(1.0, name="s(x)")
+        pred = gam.AdditivePredictor("scale", inv_link=jnp.exp, intercept=False)
+        pred += term
+
+        term.value = 2.0
+        pred.update()
+
+        assert jnp.allclose(pred.linear_predictor.value, 2.0)
+        assert jnp.allclose(pred.value, jnp.exp(2.0))
+
+    def test_terms_exclude_intercept_and_linear_predictor(self) -> None:
+        pred = gam.AdditivePredictor("loc")
+        pred += term1, term2
+
+        assert len(pred.terms) == 2
+        assert pred.intercept.name not in pred.terms
+        assert pred.linear_predictor.name not in pred.terms
+
+    def test_linear_predictor_default_names(self) -> None:
+        pred = gam.AdditivePredictor("loc")
+        assert pred.linear_predictor.name == "$\\eta_{loc}$"
+
+        pred = gam.AdditivePredictor("$\\sigma$")
+        assert pred.linear_predictor.name == "$\\eta_{\\sigma}$"
+
+    def test_linear_predictor_custom_name(self) -> None:
+        pred = gam.AdditivePredictor(
+            "loc",
+            linear_predictor_name="eta_custom{subscript}",
+        )
+
+        assert pred.linear_predictor.name == "eta_custom_{loc}"
+
+    def test_linear_predictor_is_model_node_not_var(self) -> None:
+        pred = gam.AdditivePredictor("loc")
+        model = lsl.Model([pred])
+
+        assert pred.linear_predictor.name in model.nodes
+        assert pred.linear_predictor.name not in model.vars
+        assert pred.name in model.vars
 
     def test_access_term(self) -> None:
         pred = gam.AdditivePredictor("loc")
@@ -81,8 +142,7 @@ class TestPredictor:
     def test_repr_default_intercept(self) -> None:
         pred = gam.AdditivePredictor("loc")
         assert (
-            repr(pred)
-            == "AdditivePredictor(name='loc', 0 terms, "
+            repr(pred) == "AdditivePredictor(name='loc', 0 terms, "
             "intercept='$\\\\beta_{0,loc}$')"
         )
 
@@ -105,7 +165,6 @@ class TestPredictor:
 
         assert len(pred.terms) == 2
         assert (
-            repr(pred)
-            == "AdditivePredictor(name='loc', 2 terms, "
+            repr(pred) == "AdditivePredictor(name='loc', 2 terms, "
             "intercept='$\\\\beta_{0,loc}$')"
         )


### PR DESCRIPTION
- Updated repr to display intercept status
- Exposed a new attribute `AdditivePredictor.linear_predictor` that always allows access to the untransformed link-scale version of an additive predictor.