### PR TITLE
Warn on R 4.6 ryp/Arrow/pandas issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ filterwarnings = [
     "ignore:jax.interpreters.xla.pytype_aval_mappings is deprecated:DeprecationWarning:tensorflow_probability.python.internal.backend.jax.ops",
     "ignore:shape requires ndarray or scalar arguments, got <class 'NoneType'> at position 0. In a future JAX release this will be an error.:DeprecationWarning:tensorflow_probability.python.internal.backend.jax.random_generators",
     "ignore:.*interactive_bk attribute was deprecated in Matplotlib 3.9.*:matplotlib._api.deprecation.MatplotlibDeprecationWarning",
+    "ignore:Liesel-GAM detected R 4\\.6.*:RuntimeWarning:liesel_gam",
 
     # Caused by the use in blackjax
     "ignore:JAXopt is no longer maintained:DeprecationWarning",

--- a/src/liesel_gam/__init__.py
+++ b/src/liesel_gam/__init__.py
@@ -1,4 +1,7 @@
 import os
+import re
+import warnings
+from collections.abc import Callable
 
 from . import experimental as experimental
 from . import io as io
@@ -51,15 +54,61 @@ from .var import ScaleIG as ScaleIG
 from .var import UserVar as UserVar
 from .var import VarIGPrior as VarIGPrior
 
+_R_46_PANDAS_ISSUE_URL = "https://github.com/liesel-devs/liesel_gam/issues/67"
+
+
+def _get_r_version(to_py: Callable[..., object]) -> str | None:
+    """
+    Return ryp's active R version string, if it can be queried.
+    """
+    try:
+        version = to_py("as.character(getRversion())", squeeze=True)
+    except Exception:
+        return None
+
+    version = str(version).strip()
+    if not version:
+        return None
+
+    return version.split()[0]
+
+
+def _is_r_46(version: str) -> bool:
+    """
+    Return whether an R version string identifies an R 4.6 release.
+    """
+    return re.match(r"^4\.6(?:\.|$)", version) is not None
+
+
+def _warn_if_r_46(to_py: Callable[..., object]) -> None:
+    """
+    Warn about a known R 4.6 / ryp / pandas string-column issue.
+    """
+    version = _get_r_version(to_py)
+    if version is None or not _is_r_46(version):
+        return
+
+    warnings.warn(
+        "Liesel-GAM detected R "
+        f"{version}. R 4.6 may trigger a known ryp/Arrow/pandas issue that can "
+        "corrupt pandas string column labels after R-to-Python conversion, "
+        "including in workflows that call pandas.read_csv(). See "
+        f"{_R_46_PANDAS_ISSUE_URL} for details and temporary workarounds.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+
 on_rtd = os.environ.get("READTHEDOCS", "False") == "True"
 # safeguard because R is not installed in the readthedocs build environment
 if not on_rtd:
     import pandas as pd
-    from ryp import r, to_r
+    from ryp import r, to_py, to_r
 
     try:
         to_r(pd.DataFrame({"a": [1.0, 2.0]}), "___test___")
         r("rm('___test___')")
+        _warn_if_r_46(to_py)
     except ImportError as e:
         raise ImportError(
             "Testing communication between R and Python failed. "

--- a/src/liesel_gam/__init__.py
+++ b/src/liesel_gam/__init__.py
@@ -80,12 +80,29 @@ def _is_r_46(version: str) -> bool:
     return re.match(r"^4\.6(?:\.|$)", version) is not None
 
 
-def _warn_if_r_46(to_py: Callable[..., object]) -> None:
+def _uses_r_46_pandas_workaround(pd: object) -> bool:
+    """
+    Return whether a pandas option workaround for the R 4.6 issue is active.
+    """
+    options = getattr(pd, "options", None)
+    mode = getattr(options, "mode", None)
+    future = getattr(options, "future", None)
+
+    return (
+        getattr(mode, "string_storage", None) == "python"
+        or getattr(future, "infer_string", None) is False
+    )
+
+
+def _warn_if_r_46(to_py: Callable[..., object], pd: object) -> None:
     """
     Warn about a known R 4.6 / ryp / pandas string-column issue.
     """
     version = _get_r_version(to_py)
     if version is None or not _is_r_46(version):
+        return
+
+    if _uses_r_46_pandas_workaround(pd):
         return
 
     warnings.warn(
@@ -108,7 +125,7 @@ if not on_rtd:
     try:
         to_r(pd.DataFrame({"a": [1.0, 2.0]}), "___test___")
         r("rm('___test___')")
-        _warn_if_r_46(to_py)
+        _warn_if_r_46(to_py, pd)
     except ImportError as e:
         raise ImportError(
             "Testing communication between R and Python failed. "

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,46 @@
+import warnings
+from types import SimpleNamespace
+
+import liesel_gam as gam
+
+
+def _pandas_options(*, string_storage: str = "auto", infer_string: bool = True):
+    return SimpleNamespace(
+        options=SimpleNamespace(
+            mode=SimpleNamespace(string_storage=string_storage),
+            future=SimpleNamespace(infer_string=infer_string),
+        )
+    )
+
+
+def test_r_46_warning_skipped_when_python_string_storage_active():
+    pd = _pandas_options(string_storage="python", infer_string=True)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        gam._warn_if_r_46(lambda *_, **__: "4.6.0", pd)
+
+    assert not caught
+
+
+def test_r_46_warning_skipped_when_infer_string_disabled():
+    pd = _pandas_options(string_storage="auto", infer_string=False)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        gam._warn_if_r_46(lambda *_, **__: "4.6.0", pd)
+
+    assert not caught
+
+
+def test_r_46_warning_emitted_without_workaround():
+    pd = _pandas_options(string_storage="auto", infer_string=True)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        gam._warn_if_r_46(lambda *_, **__: "4.6.0", pd)
+
+    assert len(caught) == 1
+    assert "https://github.com/liesel-devs/liesel_gam/issues/67" in str(
+        caught[0].message
+    )


### PR DESCRIPTION
Add runtime detection and warning for R 4.6 that may trigger a known ryp/Arrow/pandas string-column issue. Introduces helper functions (_get_r_version, _is_r_46, _warn_if_r_46), a constant URL to the issue, and imports (re, warnings, Callable). Call _warn_if_r_46 during package init when R is available. Also update pyproject.toml to filter out the new RuntimeWarning during test runs. See issue #67 for details and workarounds.


The warning only triggers if none of the known workarounds is active.